### PR TITLE
This patch adds double quotes around items in the retry_join section …

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ consul_agent_advertise_addr : "{% if consul_agent_use_ip %}{{ hostvars[inventory
 
 consul_agent_template : "{% if inventory_hostname in groups[consul_agent_server_group_name] %}server.json{% else %}client.json{% endif %}"
 
-consul_agent_retry_join: "{% for peer in groups[consul_agent_server_group_name] %}{% if consul_agent_use_ip %}{{hostvars[peer]['ansible_' + hostvars[peer]['consul_agent_network_iface']]['ipv4']['address'] | to_json}}{% else %}{{peer}}{% endif %}{% if not loop.last %},{% endif %}{% endfor %}"
+consul_agent_retry_join: "{% for peer in groups[consul_agent_server_group_name] %}{% if consul_agent_use_ip %}{{hostvars[peer]['ansible_' + hostvars[peer]['consul_agent_network_iface']]['ipv4']['address']| to_json}}{% else %}\"{{peer}}{% endif %}\"{% if not loop.last %},{% endif %}{% endfor %}"
 
 consul_agent_pki_key_file : '{{inventory_hostname}}{{consul_agent_pki_key_suffix}}'
 consul_agent_pki_key_src: '{{consul_agent_pki_dir}}/{{consul_agent_pki_key_file}}'


### PR DESCRIPTION
…of the consul.json.  I was unable to get the services to successfully start without them.  I tested and am currently using this on a 5 node raspberrypi model b+ cluster running hypriot.   

